### PR TITLE
List of packages required added.

### DIFF
--- a/zphisher.sh
+++ b/zphisher.sh
@@ -200,7 +200,7 @@ dependencies() {
 				elif [[ `command -v dnf` ]]; then
 					sudo dnf -y install "$pkg"
 				else
-					echo -e "\n${RED}[${WHITE}!${RED}]${RED} Unsupported package manager, Install packages manually. Packages required: php, curl, wget, unzip"
+					echo -e "\n${RED}[${WHITE}!${RED}]${RED} Unsupported package manager, Install packages manually. Packages required: php, curl, wget, unzip."
 					{ reset_color; exit 1; }
 				fi
 			}

--- a/zphisher.sh
+++ b/zphisher.sh
@@ -200,7 +200,7 @@ dependencies() {
 				elif [[ `command -v dnf` ]]; then
 					sudo dnf -y install "$pkg"
 				else
-					echo -e "\n${RED}[${WHITE}!${RED}]${RED} Unsupported package manager, Install packages manually."
+					echo -e "\n${RED}[${WHITE}!${RED}]${RED} Unsupported package manager, Install packages manually. Packages required: php, curl, wget, unzip"
 					{ reset_color; exit 1; }
 				fi
 			}


### PR DESCRIPTION
Before if the package manager was unsupported then the script would just tell that the package manager is unsupported and install packages manually, which people may not know which packages are required for zphisher to run and would have to search or look into the script code, now it tells them that which packages are required if the package manager is unsupported so they can easily install them.