### PR TITLE
add script for build deb package

### DIFF
--- a/.package/DEBIAN/control
+++ b/.package/DEBIAN/control
@@ -1,0 +1,8 @@
+Package: zphisher
+Version: 2.2
+Installed-Size: 9400
+Architecture: all
+Maintainer: @htr-tech
+Depends: php, wget, git, curl
+Homepage: https://github.com/htr-tech/zphisher
+Description: An automated phishing tool with 30+ templates. This Tool is made for educational purpose only !

--- a/.package/TERMUX/control
+++ b/.package/TERMUX/control
@@ -1,0 +1,8 @@
+Package: zphisher
+Version: 2.2
+Installed-Size: 9400
+Architecture: all
+Maintainer: @htr-tech
+Depends: php, wget, git, curl, resolv-conf, proot
+Homepage: https://github.com/htr-tech/zphisher
+Description: An automated phishing tool with 30+ templates. This Tool is made for educational purpose only !

--- a/.package/launch.sh
+++ b/.package/launch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DISTRO=$(uname -o)
+
+if [ $DISTRO == Android ]; then
+	export ZPHISHER_ROOT="/data/data/com.termux/files/usr/opt/zphisher"
+else
+	export ZPHISHER_ROOT="/usr/opt/zphisher"
+fi
+
+cd $ZPHISHER_ROOT
+bash ./zphisher.sh

--- a/make-deb.sh
+++ b/make-deb.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+PACKAGE_NAME=zphisher
+ZPHISHER_VERSION=2.2
+PACKAGE_ARCH=all
+DISTRO=$(uname -o)
+
+echo "Building Zphisher deb package..."
+
+build_termux(){
+	mkdir -p ./package/DEBIAN
+	mkdir -p ./package/data/data/com.termux/files/usr/bin
+	mkdir -p ./package/data/data/com.termux/files/usr/opt
+	cp -rf ./.package/TERMUX/control ./package/DEBIAN/control
+	mkdir -p package/data/data/com.termux/files/usr/opt/$PACKAGE_NAME
+	cp -rf ./LICENSE ./.sites ./.imgs ./zphisher.sh ./package/data/data/com.termux/files/usr/opt/$PACKAGE_NAME
+	cp -rf ./.package/launch.sh ./package/data/data/com.termux/files/usr/bin/$PACKAGE_NAME
+	chmod 755 ./package/DEBIAN
+	dpkg-deb --build ./package $PACKAGE_NAME\_$ZPHISHER_VERSION\_$PACKAGE_ARCH.deb
+
+}
+
+build_linux(){
+	mkdir -p ./package/DEBIAN
+        mkdir -p ./package/usr/bin
+        mkdir -p ./package/usr/opt
+        cp -rf ./.package/TERMUX/control ./package/DEBIAN/control
+        mkdir -p package/usr/opt/$PACKAGE_NAME
+        cp -rf ./LICENSE ./.sites ./.imgs ./zphisher.sh ./package/usr/opt/$PACKAGE_NAME
+        cp -rf ./.package/launch.sh ./package/usr/bin/$PACKAGE_NAME
+        chmod 755 ./package/DEBIAN
+        dpkg-deb --build ./package $PACKAGE_NAME\_$ZPHISHER_VERSION\_$PACKAGE_ARCH.deb
+}
+
+if [ $DISTRO == Android ]; then
+        build_termux
+else
+        build_linux
+fi

--- a/make-deb.sh
+++ b/make-deb.sh
@@ -23,7 +23,7 @@ build_linux(){
 	mkdir -p ./package/DEBIAN
         mkdir -p ./package/usr/bin
         mkdir -p ./package/usr/opt
-        cp -rf ./.package/TERMUX/control ./package/DEBIAN/control
+        cp -rf ./.package/DEBIAN/control ./package/DEBIAN/control
         mkdir -p package/usr/opt/$PACKAGE_NAME
         cp -rf ./LICENSE ./.sites ./.imgs ./zphisher.sh ./package/usr/opt/$PACKAGE_NAME
         cp -rf ./.package/launch.sh ./package/usr/bin/$PACKAGE_NAME


### PR DESCRIPTION
![Screenshot_20211217-170028](https://user-images.githubusercontent.com/64093255/146613081-883b5aae-eb22-462e-84a8-f73f354f3d1f.png)

I think a clean installation using a deb package is better, maintainers will be able to generate a linux/termux package of your project easily, and you will also be able to use the script to publish these packages in each update/release. 