### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
-FROM debian:10
+FROM debian:latest
 LABEL MAINTAINER="https://github.com/htr-tech/zphisher"
 
 WORKDIR zphisher/
 ADD . /zphisher
 
-RUN apt-get update
-RUN apt-get install -y curl
-RUN apt-get install --no-install-recommends -y php
-RUN apt-get install -y unzip
-RUN apt-get clean
-RUN apt-get install -y wget
-
+RUN apt update && apt full-upgrade -y && apt install -y curl unzip wget && apt install --no-install-recommends -y php && apt clean
 CMD ["./zphisher.sh"]


### PR DESCRIPTION
Simple Dockerfile impovement.
According to best practices, the amount of "RUN" instructions should be minimized - for efficiency purposes.
Less "RUN" instructions => less unnecessary Docker layers (11 vs 6).

Therefore, everything apt related can be fitted into one "RUN" instruction.

Plus, a "latest" tag seems to be a more automated solution for pulling latest debian image.