### PR TITLE
Unify build call for .deb package + Dockerfile visual improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM debian:latest
 LABEL MAINTAINER="https://github.com/htr-tech/zphisher"
 
-WORKDIR zphisher/
+WORKDIR /zphisher/
 ADD . /zphisher
 
-RUN apt update && apt full-upgrade -y && apt install -y curl unzip wget && apt install --no-install-recommends -y php && apt clean
+RUN apt update && \
+    apt full-upgrade -y && \
+    apt install -y curl unzip wget && \
+    apt install --no-install-recommends -y php && \
+    apt clean
 CMD ["./zphisher.sh"]

--- a/make-deb.sh
+++ b/make-deb.sh
@@ -4,35 +4,32 @@ ZPHISHER_VERSION=2.2
 PACKAGE_ARCH=all
 DISTRO=$(uname -o)
 
-echo "Building Zphisher deb package..."
 
-build_termux(){
-	mkdir -p ./package/DEBIAN
-	mkdir -p ./package/data/data/com.termux/files/usr/bin
-	mkdir -p ./package/data/data/com.termux/files/usr/opt
-	cp -rf ./.package/TERMUX/control ./package/DEBIAN/control
-	mkdir -p package/data/data/com.termux/files/usr/opt/$PACKAGE_NAME
-	cp -rf ./LICENSE ./.sites ./.imgs ./zphisher.sh ./package/data/data/com.termux/files/usr/opt/$PACKAGE_NAME
-	cp -rf ./.package/launch.sh ./package/data/data/com.termux/files/usr/bin/$PACKAGE_NAME
+build_package() {
+        # define variables depending on detected platform
+        distr_name=$1
+        if [ "$distr_name" == "Android" ]; then
+                platform="Termux"
+                path_part="data/data/com.termux/files/"
+        else
+                platform="Debian"
+                path_part=""
+        fi
+        # print out message with detected platform
+        echo "Building .deb package for: $platform"
+        # run preparations and build package
+        platform=${platform^^}
+        mkdir -p ./package/DEBIAN
+	mkdir -p ./package/"$path_part"usr/bin
+	mkdir -p ./package/"$path_part"usr/opt
+	cp -rf ./.package/"$platform"/control ./package/DEBIAN/control
+	mkdir -p package/"$path_part"usr/opt/$PACKAGE_NAME
+	cp -rf ./LICENSE ./.sites ./.imgs ./zphisher.sh ./package/"$path_part"usr/opt/$PACKAGE_NAME
+	cp -rf ./.package/launch.sh ./package/"$path_part"usr/bin/$PACKAGE_NAME
 	chmod 755 ./package/DEBIAN
 	dpkg-deb --build ./package $PACKAGE_NAME\_$ZPHISHER_VERSION\_$PACKAGE_ARCH.deb
-
 }
 
-build_linux(){
-	mkdir -p ./package/DEBIAN
-        mkdir -p ./package/usr/bin
-        mkdir -p ./package/usr/opt
-        cp -rf ./.package/DEBIAN/control ./package/DEBIAN/control
-        mkdir -p package/usr/opt/$PACKAGE_NAME
-        cp -rf ./LICENSE ./.sites ./.imgs ./zphisher.sh ./package/usr/opt/$PACKAGE_NAME
-        cp -rf ./.package/launch.sh ./package/usr/bin/$PACKAGE_NAME
-        chmod 755 ./package/DEBIAN
-        dpkg-deb --build ./package $PACKAGE_NAME\_$ZPHISHER_VERSION\_$PACKAGE_ARCH.deb
-}
 
-if [ $DISTRO == Android ]; then
-        build_termux
-else
-        build_linux
-fi
+# launch the build
+build_package $DISTRO


### PR DESCRIPTION
Changes:
1. `build_termux()` and `build_linux()` are merged into unified **`build_package()`**;
2. some minor visual improvements are added into Dockerfile.


**1. make-deb.sh**
I've noticed there is a number of almost identical `mkdir -p` calls (and others) in make-deb.sh script.
The only difference was the middle part of paths and platform name (TERMUX or DEBIAN).

To avoid that code duplication I've written a parametrized `build_package()`, which can be used for both Termux and Debian builds.


**2. Dockerfile**
Changes here are just for visual improvement.
In commit history I noticed that someone else has already done this, but somewhere in the midway Dockerfile got fully deleted and then reincarnated as it's "not so" efficient version.

So basically I'm just bringing back some of the original author's work.

Also I'm fixing my own error - in previous PR I forgot to add a newline at the EOF.